### PR TITLE
Fix aliased classes

### DIFF
--- a/src/griffe_pydantic/static.py
+++ b/src/griffe_pydantic/static.py
@@ -7,11 +7,8 @@ import sys
 from typing import TYPE_CHECKING
 
 from griffe import (
-    Alias,
-    AliasResolutionError,
     Attribute,
     Class,
-    CyclicAliasError,
     Docstring,
     Expr,
     ExprCall,

--- a/src/griffe_pydantic/static.py
+++ b/src/griffe_pydantic/static.py
@@ -7,6 +7,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from griffe import (
+    Alias,
     Attribute,
     Class,
     Docstring,
@@ -104,6 +105,10 @@ def process_function(func: Function, cls: Class, *, processed: set[str]) -> None
     if func.canonical_path in processed:
         return
     processed.add(func.canonical_path)
+
+    if isinstance(func, Alias):
+        logger.warning(f"cannot yet process {func}")
+        return
 
     if decorator := pydantic_field_validator(func):
         fields = [ast.literal_eval(field) for field in decorator.arguments if isinstance(field, str)]

--- a/src/griffe_pydantic/static.py
+++ b/src/griffe_pydantic/static.py
@@ -156,9 +156,12 @@ def process_class(cls: Class, *, processed: set[str], schema: bool = False) -> N
         cls.extra[common.self_namespace]["schema"] = common.json_schema(true_class)
 
     for member in cls.all_members.values():
-        if isinstance(member, Alias) and (member := _resolve_alias(member)) is None:
-            logger.warning(f"cannot yet process {member}")
-            continue
+        if isinstance(member, Alias):
+            resolved = _resolve_alias(member)
+            if resolved is None:
+                logger.warning(f"cannot yet process {member}")
+                continue
+            member = resolved
         if isinstance(member, Attribute):
             process_attribute(member, cls, processed=processed)
         elif isinstance(member, Function):

--- a/src/griffe_pydantic/static.py
+++ b/src/griffe_pydantic/static.py
@@ -162,6 +162,7 @@ def process_module(
     processed.add(mod.canonical_path)
 
     for cls in mod.classes.values():
+        # Don't process aliases, real classes will be processed at some point anyway.
         if not cls.is_alias:
             process_class(cls, processed=processed, schema=schema)
 

--- a/src/griffe_pydantic/static.py
+++ b/src/griffe_pydantic/static.py
@@ -161,7 +161,7 @@ def process_class(cls: Class, *, processed: set[str], schema: bool = False) -> N
             if resolved is None:
                 logger.warning(f"cannot yet process {member}")
                 continue
-            member = resolved
+            member = resolved  # noqa: PLW2901
         if isinstance(member, Attribute):
             process_attribute(member, cls, processed=processed)
         elif isinstance(member, Function):

--- a/src/griffe_pydantic/static.py
+++ b/src/griffe_pydantic/static.py
@@ -140,12 +140,6 @@ def process_class(cls: Class, *, processed: set[str], schema: bool = False) -> N
         cls.extra[common.self_namespace]["schema"] = common.json_schema(true_class)
 
     for member in cls.all_members.values():
-        if isinstance(member, Alias):
-            try:
-                member = member.final_target  # noqa: PLW2901
-            except (AliasResolutionError, CyclicAliasError):
-                logger.warning(f"cannot yet process {member}")
-                continue
         if isinstance(member, Attribute):
             process_attribute(member, cls, processed=processed)
         elif isinstance(member, Function):
@@ -166,7 +160,8 @@ def process_module(
     processed.add(mod.canonical_path)
 
     for cls in mod.classes.values():
-        process_class(cls, processed=processed, schema=schema)
+        if not cls.is_alias:
+            process_class(cls, processed=processed, schema=schema)
 
     for submodule in mod.modules.values():
         process_module(submodule, processed=processed, schema=schema)

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -72,7 +72,6 @@ def test_extension() -> None:
         assert schema.startswith('{\n  "description"')
 
 
-
 def test_imported_models() -> None:
     """Test the extension with imported models."""
     with temporary_visited_package(

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -70,3 +70,18 @@ def test_extension() -> None:
 
         schema = package.classes["ExampleModel"].extra["griffe_pydantic"]["schema"]
         assert schema.startswith('{\n  "description"')
+
+
+
+def test_imported_models() -> None:
+    """Test the extension with imported models."""
+    with temporary_visited_package(
+        "package",
+        modules={
+            "__init__.py": "from ._private import MyModel\n\n__all__ = ['MyModel']",
+            "_private.py": "from pydantic import BaseModel\n\nclass MyModel(BaseModel):\n    field1: str\n    '''Some field.'''\n",
+        },
+        extensions=Extensions(PydanticExtension(schema=True)),
+    ) as package:
+        assert package["MyModel"].labels == {"pydantic-model"}
+        assert package["MyModel.field1"].labels == {"pydantic-field"}


### PR DESCRIPTION
Currently models re-exposed via e.g. ``__init__.py`` will be correctly flagged as models, but their fields won't be flagged due to them being aliases rather than ``Attribute`` objects.