### PR TITLE
feat: Custom base class detection

### DIFF
--- a/src/griffe_pydantic/_internal/common.py
+++ b/src/griffe_pydantic/_internal/common.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import importlib
 import json
+import sys
 from functools import partial
 from typing import TYPE_CHECKING
+
+from griffe import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -10,8 +14,19 @@ if TYPE_CHECKING:
     from griffe import Attribute, Class, Function
     from pydantic import BaseModel
 
+_DEFAULT_BASES = (
+    "pydantic.BaseModel",
+    "pydantic.main.BaseModel",
+    "pydantic_settings.BaseSettings",
+    "pydantic_settings.main.BaseSettings",
+    "sqlmodel.SQLModel",
+    "sqlmodel.main.SQLModel",
+)
+
+
 _self_namespace = "griffe_pydantic"
 _mkdocstrings_namespace = "mkdocstrings"
+_logger = get_logger(__name__)
 
 _field_constraints = {
     "gt",
@@ -77,3 +92,30 @@ def _process_function(func: Function, cls: Class, fields: Sequence[str]) -> None
     for target in targets:
         target.extra[_self_namespace].setdefault("validators", [])
         target.extra[_self_namespace]["validators"].append(func)
+
+
+def _import_from_name(name: str) -> type[BaseModel]:
+    """Given a fully-qualified `package.module.Class` name, return the imported class."""
+    module_name, _, class_name = name.rpartition(".")
+    module = sys.modules.get(module_name, importlib.import_module(module_name))
+    try:
+        return getattr(module, class_name)
+    except AttributeError as e:
+        raise AttributeError(f"No class {class_name} in module {module}") from e
+
+
+def _import_bases(names: tuple[str, ...]) -> tuple[type[BaseModel], ...]:
+    """Import a set of bases from fully-qualified `package.module.Class` names.
+
+    Does not raise for import errors,
+    since we don't expect all possible bases to be present.
+    """
+    bases = []
+    for name in names:
+        try:
+            bases.append(_import_from_name(name))
+        except ImportError:
+            # fine, we expect some of the defaults to fail, we only care if we have none
+            _logger.debug("Could not import %s", name)
+
+    return tuple(bases)

--- a/src/griffe_pydantic/_internal/extension.py
+++ b/src/griffe_pydantic/_internal/extension.py
@@ -10,7 +10,7 @@ from griffe import (
     get_logger,
 )
 
-from griffe_pydantic._internal import dynamic, static
+from griffe_pydantic._internal import common, dynamic, static
 
 if TYPE_CHECKING:
     from griffe import ObjectNode
@@ -22,14 +22,26 @@ _logger = get_logger(__name__)
 class PydanticExtension(Extension):
     """Griffe extension for Pydantic."""
 
-    def __init__(self, *, schema: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        schema: bool = False,
+        bases: tuple[str, ...] | list[str] = common._DEFAULT_BASES,
+        include_bases: tuple[str, ...] | list[str] | None = None,
+    ) -> None:
         """Initialize the extension.
 
         Parameters:
             schema: Whether to compute and store the JSON schema of models.
+            bases: Tuple of complete `package.module.Class` references to base classes that should be considered
+                pydantic models. Declaring this *replaces* the default bases.
+            include_bases: *Additional* base classes to consider as pydantic models, including the defaults.
         """
         super().__init__()
         self._schema = schema
+        self._bases = tuple(bases)
+        if include_bases:
+            self._bases += tuple(include_bases)
         self._processed: set[str] = set()
         self._recorded: list[tuple[ObjectNode, Class]] = []
 
@@ -38,7 +50,7 @@ class PydanticExtension(Extension):
         for node, cls in self._recorded:
             self._processed.add(cls.canonical_path)
             dynamic._process_class(node.obj, cls, processed=self._processed, schema=self._schema)
-        static._process_module(pkg, processed=self._processed, schema=self._schema)
+        static._process_module(pkg, processed=self._processed, schema=self._schema, bases=self._bases)
 
     def on_class_instance(self, *, node: ast.AST | ObjectNode, cls: Class, **kwargs: Any) -> None:  # noqa: ARG002
         """Detect and prepare Pydantic models."""
@@ -46,11 +58,13 @@ class PydanticExtension(Extension):
         if isinstance(node, ast.AST):
             return
 
-        try:
-            import pydantic
-        except ImportError:
-            _logger.warning("could not import pydantic - models will not be detected")
+        bases = common._import_bases(self._bases)
+        if not bases:
+            _logger.warning(
+                "could not import any expected model base - models will not be detected. \nexpected: %s",
+                self._bases,
+            )
             return
 
-        if issubclass(node.obj, pydantic.BaseModel):
+        if issubclass(node.obj, bases):
             self._recorded.append((node, cls))


### PR DESCRIPTION
Fix: https://github.com/mkdocstrings/griffe-pydantic/issues/27

Here's an attempt at #27. If the approach is OK, i'll write the docs for it :)

New to mkdocs, so sorry if i did this wrong.

The gist is rather than keeping an infinite list of all the possible things that could be pydantic models, we just allow someone to specify a non-standard base for detection of e.g. sqlmodel, pydantic-settings, and any other wrappers. hopefully this saves us from having to import them (?)

Two ways:

Adding to the defaults

```yaml
extensions:
  - griffe_pydantic:
      include_bases: ["mypackage.MyBase"]
```

Replacing the defaults (if we for some reason didn't want to document regular pydantic models and only wanted to document our special kind

```yaml
extensions:
  - griffe_pydantic:
      bases: ["mypackage.MyBase"]
```

edit: need to fix that docs build check but i'm not exactly sure what the configuration error is from the message. sorry for the red-x-open, will get to this tmrw