### PR TITLE
Log encountering `Alias`es on the DEBUG level

### DIFF
--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -232,30 +232,3 @@ def test_process_non_model_base_class_fields() -> None:
         extensions=Extensions(PydanticExtension(schema=False)),
     ) as package:
         assert "pydantic-field" in package["B.a"].labels
-
-def test_log_alias_debug_level(caplog: pytest.LogCaptureFixture) -> None:
-    """Test that alias debug logging works correctly."""
-    code_init = """
-    from .foo import Foo
-    class Bar(Foo):
-        pass
-    """
-    code_foo = """
-    from pydantic import BaseModel
-    class Foo(BaseModel):
-        def func(self) -> None:
-            pass
-    """
-    with (
-        caplog.at_level(logging.DEBUG),
-        temporary_visited_package(
-            "package",
-            modules={"__init__.py": code_init, "foo.py": code_foo},
-            extensions=Extensions(PydanticExtension(schema=False)),
-        ),
-    ):
-        assert any(
-            record.levelname == "DEBUG"
-            and record.message.startswith("cannot yet process Alias")
-            for record in caplog.records
-        )


### PR DESCRIPTION
Log encountering aliases in `_process_function` on the `DEBUG` level instead of the current `WARNING` level. Addresses #31.

I also added a small test in which a method becomes such an alias. It may be useful for figuring out why those functions are treated as `Alias`es in the first place, but please feel free to remove it if that's not the case.