### PR TITLE
feat: Supports Pydantic Field defined via Annotated

### DIFF
--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -235,7 +235,6 @@ def test_process_non_model_base_class_fields() -> None:
         assert "pydantic-field" in package["B.a"].labels
 
 
-@pytest.mark.skip(reason="Currently not supported.")
 def test_annotated_fields() -> None:
     """Test the extension with annotated fields."""
     code = """
@@ -255,5 +254,8 @@ def test_annotated_fields() -> None:
         assert package["Model.b"].is_attribute
         assert "pydantic-field" in package["Model.a"].labels
         assert "pydantic-field" in package["Model.b"].labels
-        assert package["Model.a"].docstring == "Some description."
-        assert package["Model.b"].docstring == "Another description."
+        assert package["Model.a"].docstring.value == "Some description."
+        assert package["Model.b"].docstring.value == "Another description."
+        # Check that annotation is the actual type, not Annotated[...]
+        assert str(package["Model.a"].annotation) == "int"
+        assert str(package["Model.b"].annotation) == "int"


### PR DESCRIPTION
### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [ ] I did not use AI
- [x] I used AI and thorougly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->

The proposed changes are able to detect when the `Field()` is defined with `Annotated[type, Field(...)]` and it overwrites the annotation type such that the final docs won't show the full Annotated.

#### Example

Before

<img width="793" height="136" alt="image" src="https://github.com/user-attachments/assets/a867e32f-1123-4209-886c-84d9b47140c3" />


After

<img width="806" height="158" alt="image" src="https://github.com/user-attachments/assets/d8882b92-e3a2-4604-9ce0-6adfa262b22d" />



### Relevant resources

- Resolves #37
